### PR TITLE
Fix method accessibility issue with Base method

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -472,7 +472,7 @@ class Db extends Beanstalk
         throw new BadMethod('"read" is not a valid method in DB queues.');
     }
 
-    protected function write($data)
+    public function write($data)
     {
         throw new BadMethod('"write" is not a valid method in DB queues.');
     }


### PR DESCRIPTION
`write` method has protected visibility but the base method has public visibility and it  cause a
 PHP Fatal error:  Access level to Phalcon\Queue\Db::write() must be public (as in class Phalcon\Queue\Beanstalk) in